### PR TITLE
Adopt dataclasses for analysis results

### DIFF
--- a/crackpy/fracture_analysis/plot.py
+++ b/crackpy/fracture_analysis/plot.py
@@ -238,8 +238,8 @@ class Plotter:
             # J integral result
             props = dict(boxstyle='round', facecolor='gray', alpha=0.4)
             text = "J-integral\n\n" + \
-                   f"$J$ = {self.analysis.sifs_int['rej_out_mean']['j']:.2f} $N*mm^{{-1}}$\n" + \
-                   f"$K_J$ = {self.analysis.sifs_int['rej_out_mean']['sif_j']:.2f} $MPa*m^{{1/2}}$"
+                   f"$J$ = {self.analysis.sifs_int['rej_out_mean'].J:.2f} $N*mm^{{-1}}$\n" + \
+                   f"$K_J$ = {self.analysis.sifs_int['rej_out_mean'].K_J:.2f} $MPa*m^{{1/2}}$"
             self.ax_results.text(0.1, 0.97, text.replace('*', '\\cdot '),
                                  transform=self.ax_results.transAxes, fontsize=14,
                                  verticalalignment='top', bbox=props)
@@ -247,18 +247,18 @@ class Plotter:
             # Williams integration results
             props = dict(boxstyle='round', facecolor='gray', alpha=0.4)
             text = "Interaction integral\n\n" + \
-                   f"$K_I$ = {self.analysis.sifs_int['rej_out_mean']['sif_k_i']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$K_{{II}}$ = {self.analysis.sifs_int['rej_out_mean']['sif_k_ii']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$T$ = {self.analysis.sifs_int['rej_out_mean']['t_stress_int']:.2f} $MPa$"
+                   f"$K_I$ = {self.analysis.sifs_int['rej_out_mean'].K_I_interac:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$K_{{II}}$ = {self.analysis.sifs_int['rej_out_mean'].K_II_interac:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$T$ = {self.analysis.sifs_int['rej_out_mean'].T_interac:.2f} $MPa$"
             self.ax_results.text(0.1, 0.8, text.replace('*', '\\cdot '),
                                  transform=self.ax_results.transAxes, fontsize=14,
                                  verticalalignment='top', bbox=props)
 
             props = dict(boxstyle='round', facecolor='gray', alpha=0.4)
             text = "Bueckner integral\n\n" + \
-                   f"$K_I$ = {self.analysis.sifs_int['rej_out_mean']['k_i_chen']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$K_{{II}}$ = {self.analysis.sifs_int['rej_out_mean']['k_ii_chen']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$T$ = {self.analysis.sifs_int['rej_out_mean']['t_stress_chen']:.2f} $MPa$"
+                   f"$K_I$ = {self.analysis.sifs_int['rej_out_mean'].K_I_Chen:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$K_{{II}}$ = {self.analysis.sifs_int['rej_out_mean'].K_II_Chen:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$T$ = {self.analysis.sifs_int['rej_out_mean'].T_Chen:.2f} $MPa$"
             self.ax_results.text(0.1, 0.6, text.replace('*', '\\cdot '),
                                  transform=self.ax_results.transAxes, fontsize=14,
                                  verticalalignment='top', bbox=props)
@@ -270,9 +270,9 @@ class Plotter:
             # Williams fitting results
             props = dict(boxstyle='round', facecolor='gray', alpha=0.4)
             text = "Williams fitting\n\n" + \
-                   f"$K_I$ = {self.analysis.sifs_fit['K_I']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$K_{{II}}$ = {self.analysis.sifs_fit['K_II']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$T$ = {self.analysis.sifs_fit['T']:.2f} $MPa$"
+                   f"$K_I$ = {self.analysis.sifs_fit.K_I:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$K_{{II}}$ = {self.analysis.sifs_fit.K_II:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$T$ = {self.analysis.sifs_fit.T:.2f} $MPa$"
             self.ax_results.text(0.1, 0.4, text.replace('*', '\\cdot '),
                                  transform=self.ax_results.transAxes, fontsize=14,
                                  verticalalignment='top', bbox=props)
@@ -280,11 +280,11 @@ class Plotter:
             # CJP fitting results
             props = dict(boxstyle='round', facecolor='gray', alpha=0.4)
             text = "CJP fitting\n\n" + \
-                   f"$K_F$ = {self.analysis.res_cjp['K_F']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$K_R$ = {self.analysis.res_cjp['K_R']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$K_S$ = {self.analysis.res_cjp['K_S']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$K_{{II}}$ = {self.analysis.res_cjp['K_II']:.2f} $MPa*m^{{1/2}}$\n" + \
-                   f"$T$ = {self.analysis.res_cjp['T']:.2f} $MPa$"
+                   f"$K_F$ = {self.analysis.res_cjp.K_F:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$K_R$ = {self.analysis.res_cjp.K_R:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$K_S$ = {self.analysis.res_cjp.K_S:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$K_{{II}}$ = {self.analysis.res_cjp.K_II:.2f} $MPa*m^{{1/2}}$\n" + \
+                   f"$T$ = {self.analysis.res_cjp.T:.2f} $MPa$"
             self.ax_results.text(0.1, 0.2, text.replace('*', '\\cdot '),
                                  transform=self.ax_results.transAxes, fontsize=14,
                                  verticalalignment='top', bbox=props)

--- a/crackpy/fracture_analysis/write.py
+++ b/crackpy/fracture_analysis/write.py
@@ -81,12 +81,12 @@ class OutputWriter:
                 file.write('\n')
                 file.write('<CJP_results>\n')
                 file.write(f'{"Param":>10}, {"Unit":>20}, {"Result":>20} \n')
-                file.write(f'{"Error":>10}, {"1":>20}, {self.analysis.res_cjp["Error"]:20.10f} \n')
-                file.write(f'{"K_F":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.res_cjp["K_F"]:20.10f} \n')
-                file.write(f'{"K_R":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.res_cjp["K_R"]:20.10f} \n')
-                file.write(f'{"K_S":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.res_cjp["K_S"]:20.10f} \n')
-                file.write(f'{"K_II":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.res_cjp["K_II"]:20.10f} \n')
-                file.write(f'{"T":>10}, {"MPa":>20}, {self.analysis.res_cjp["T"]:20.10f} \n')
+                file.write(f'{"Error":>10}, {"1":>20}, {self.analysis.res_cjp.error:20.10f} \n')
+                file.write(f'{"K_F":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.res_cjp.K_F:20.10f} \n')
+                file.write(f'{"K_R":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.res_cjp.K_R:20.10f} \n')
+                file.write(f'{"K_S":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.res_cjp.K_S:20.10f} \n')
+                file.write(f'{"K_II":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.res_cjp.K_II:20.10f} \n')
+                file.write(f'{"T":>10}, {"MPa":>20}, {self.analysis.res_cjp.T:20.10f} \n')
                 file.write('</CJP_results>\n')
                 file.write('\n')
 
@@ -96,10 +96,10 @@ class OutputWriter:
                 file.write('\n')
                 file.write('<Williams_fit_results>\n')
                 file.write(f'{"Param":>10}, {"Unit":>20}, {"Result":>20} \n')
-                file.write(f'{"Error":>10}, {"1":>20}, {self.analysis.sifs_fit["Error"]:20.10f} \n')
-                file.write(f'{"K_I":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.sifs_fit["K_I"]:20.10f} \n')
-                file.write(f'{"K_II":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.sifs_fit["K_II"]:20.10f} \n')
-                file.write(f'{"T":>10}, {"MPa":>20}, {self.analysis.sifs_fit["T"]:20.10f} \n')
+                file.write(f'{"Error":>10}, {"1":>20}, {self.analysis.sifs_fit.error:20.10f} \n')
+                file.write(f'{"K_I":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.sifs_fit.K_I:20.10f} \n')
+                file.write(f'{"K_II":>10}, {"MPa*m^{1/2}":>20}, {self.analysis.sifs_fit.K_II:20.10f} \n')
+                file.write(f'{"T":>10}, {"MPa":>20}, {self.analysis.sifs_fit.T:20.10f} \n')
                 for n, a in self.analysis.williams_fit_a_n.items():
                     file.write(f'{f"a_{n}":>10}, {unit_of_williams_coefficients(n):>20}, {a:20.10f} \n')
                 for n, b in self.analysis.williams_fit_b_n.items():
@@ -117,55 +117,55 @@ class OutputWriter:
                 file.write(f'{"Param":>20}, {"Unit":>20}, {"Mean":>20}, {"Median":>20}, {"Mean_wo_outliers":>20} \n')
                 file.write(
                     f'{"J":>20}, {"N/mm":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["j"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["j"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["j"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].J:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].J:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].J:20.10f}\n')
                 file.write(
                     f'{"K_J":>20}, {"MPa*m^{1/2}":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["sif_j"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["sif_j"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["sif_j"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].K_J:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].K_J:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].K_J:20.10f}\n')
                 file.write(
                     f'{"K_I_interac":>20}, '
                     f'{"MPa*m^{1/2}":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["sif_k_i"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["sif_k_i"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["sif_k_i"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].K_I_interac:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].K_I_interac:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].K_I_interac:20.10f}\n')
                 file.write(
                     f'{"K_II_interac":>20}, '
                     f'{"MPa*m^{1/2}":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["sif_k_ii"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["sif_k_ii"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["sif_k_ii"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].K_II_interac:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].K_II_interac:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].K_II_interac:20.10f}\n')
                 file.write(
                     f'{"T_interac":>20}, {"MPa":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["t_stress_int"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["t_stress_int"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["t_stress_int"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].T_interac:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].T_interac:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].T_interac:20.10f}\n')
                 file.write(
                     f'{"K_I_Chen":>20}, '
                     f'{"MPa*m^{1/2}":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["k_i_chen"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["k_i_chen"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["k_i_chen"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].K_I_Chen:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].K_I_Chen:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].K_I_Chen:20.10f}\n')
                 file.write(
                     f'{"K_II_Chen":>20}, '
                     f'{"MPa*m^{1/2}":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["k_ii_chen"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["k_ii_chen"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["k_ii_chen"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].K_II_Chen:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].K_II_Chen:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].K_II_Chen:20.10f}\n')
                 file.write(
                     f'{"T_Chen":>20}, '
                     f'{"MPa":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["t_stress_chen"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["t_stress_chen"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["t_stress_chen"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].T_Chen:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].T_Chen:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].T_Chen:20.10f}\n')
                 file.write(
                     f'{"T_SDM":>20}, '
                     f'{"MPa":>20}, '
-                    f'{self.analysis.sifs_int["mean"]["t_stress_sdm"]:20.10f}, '
-                    f'{self.analysis.sifs_int["median"]["t_stress_sdm"]:20.10f}, '
-                    f'{self.analysis.sifs_int["rej_out_mean"]["t_stress_sdm"]:20.10f}\n')
+                    f'{self.analysis.sifs_int["mean"].T_SDM:20.10f}, '
+                    f'{self.analysis.sifs_int["median"].T_SDM:20.10f}, '
+                    f'{self.analysis.sifs_int["rej_out_mean"].T_SDM:20.10f}\n')
 
                 file.write('</SIFs_integral>\n')
                 file.write("\n")
@@ -186,17 +186,17 @@ class OutputWriter:
                         file.write(
                             f'{f"a_{term:.0f}":>10}, '
                             f'{unit_of_williams_coefficients(term):>20}, '
-                            f'{self.analysis.sifs_int["mean"]["williams_int_a_n"][term_index]:20.10f}, '
-                            f'{self.analysis.sifs_int["median"]["williams_int_a_n"][term_index]:20.10f}, '
-                            f'{self.analysis.sifs_int["rej_out_mean"]["williams_int_a_n"][term_index]:20.10f}\n')
+                            f'{self.analysis.sifs_int["williams_int_a_n"]["mean"][term_index]:20.10f}, '
+                            f'{self.analysis.sifs_int["williams_int_a_n"]["median"][term_index]:20.10f}, '
+                            f'{self.analysis.sifs_int["williams_int_a_n"]["rej_out_mean"][term_index]:20.10f}\n')
 
                     for term_index, term in enumerate(terms):
                         file.write(
                             f'{f"b_{term:.0f}":>10}, '
                             f'{unit_of_williams_coefficients(term):>20}, '
-                            f'{self.analysis.sifs_int["mean"]["williams_int_b_n"][term_index]:20.10f}, '
-                            f'{self.analysis.sifs_int["median"]["williams_int_b_n"][term_index]:20.10f}, '
-                            f'{self.analysis.sifs_int["rej_out_mean"]["williams_int_b_n"][term_index]:20.10f}\n')
+                            f'{self.analysis.sifs_int["williams_int_b_n"]["mean"][term_index]:20.10f}, '
+                            f'{self.analysis.sifs_int["williams_int_b_n"]["median"][term_index]:20.10f}, '
+                            f'{self.analysis.sifs_int["williams_int_b_n"]["rej_out_mean"][term_index]:20.10f}\n')
 
                     file.write('</Bueckner_Chen_integral>\n')
                     file.write('\n')
@@ -345,27 +345,27 @@ class OutputWriter:
 
         json_dict['CJP_results'] = {}
         json_dict['CJP_results']['error'] = {"unit": "1",
-                                             "result": self.analysis.res_cjp["Error"]}
+                                             "result": self.analysis.res_cjp.error}
         json_dict['CJP_results']['K_F'] = {"unit": "MPa*m^{1/2}",
-                                           "result": self.analysis.res_cjp["K_F"]}
+                                           "result": self.analysis.res_cjp.K_F}
         json_dict['CJP_results']['K_R'] = {"unit": "MPa*m^{1/2}",
-                                           "result": self.analysis.res_cjp["K_R"]}
+                                           "result": self.analysis.res_cjp.K_R}
         json_dict['CJP_results']['K_S'] = {"unit": "MPa*m^{1/2}",
-                                           "result": self.analysis.res_cjp["K_S"]}
+                                           "result": self.analysis.res_cjp.K_S}
         json_dict['CJP_results']['K_II'] = {"unit": "MPa*m^{1/2}",
-                                            "result": self.analysis.res_cjp["K_II"]}
+                                            "result": self.analysis.res_cjp.K_II}
         json_dict['CJP_results']['T'] = {"unit": "MPa",
-                                         "result": self.analysis.res_cjp["T"]}
+                                         "result": self.analysis.res_cjp.T}
 
         json_dict['Williams_fit_results'] = {}
         json_dict['Williams_fit_results']['error'] = {"unit": "1",
-                                                      "result": self.analysis.sifs_fit["Error"]}
+                                                      "result": self.analysis.sifs_fit.error}
         json_dict['Williams_fit_results']['K_I'] = {"unit": "MPa*m^{1/2}",
-                                                    "result": self.analysis.sifs_fit["K_I"]}
+                                                    "result": self.analysis.sifs_fit.K_I}
         json_dict['Williams_fit_results']['K_II'] = {"unit": "MPa*m^{1/2}",
-                                                     "result": self.analysis.sifs_fit["K_II"]}
+                                                     "result": self.analysis.sifs_fit.K_II}
         json_dict['Williams_fit_results']['T'] = {"unit": "MPa",
-                                                  "result": self.analysis.sifs_fit["T"]}
+                                                  "result": self.analysis.sifs_fit.T}
         for n, a in self.analysis.williams_fit_a_n.items():
             json_dict['Williams_fit_results'][f'a_{n}'] = {"unit": unit_of_williams_coefficients(n),
                                                            "result": a}
@@ -375,70 +375,55 @@ class OutputWriter:
 
         json_dict['SIFs_integral'] = {}
         json_dict['SIFs_integral']['J'] = {"unit": "N/mm",
-                                           "mean": self.analysis.sifs_int["mean"]["j"],
-                                           "median": self.analysis.sifs_int["median"]["j"],
-                                           "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"]["j"]}
+                                           "mean": self.analysis.sifs_int["mean"].J,
+                                           "median": self.analysis.sifs_int["median"].J,
+                                           "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].J}
         json_dict['SIFs_integral']['K_J'] = {"unit": "MPa*m^{1/2}",
-                                             "mean": self.analysis.sifs_int["mean"]["sif_j"],
-                                             "median": self.analysis.sifs_int["median"]["sif_j"],
-                                             "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"]["sif_j"]}
+                                             "mean": self.analysis.sifs_int["mean"].K_J,
+                                             "median": self.analysis.sifs_int["median"].K_J,
+                                             "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].K_J}
         json_dict['SIFs_integral']['K_I_interac'] = {"unit": "MPa*m^{1/2}",
-                                                     "mean": self.analysis.sifs_int["mean"]["sif_k_i"],
-                                                     "median": self.analysis.sifs_int["median"]["sif_k_i"],
-                                                     "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"][
-                                                         "sif_k_i"]}
+                                                     "mean": self.analysis.sifs_int["mean"].K_I_interac,
+                                                     "median": self.analysis.sifs_int["median"].K_I_interac,
+                                                     "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].K_I_interac}
         json_dict['SIFs_integral']['K_II_interac'] = {"unit": "MPa*m^{1/2}",
-                                                      "mean": self.analysis.sifs_int["mean"]["sif_k_ii"],
-                                                      "median": self.analysis.sifs_int["median"]["sif_k_ii"],
-                                                      "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"][
-                                                          "sif_k_ii"]}
+                                                      "mean": self.analysis.sifs_int["mean"].K_II_interac,
+                                                      "median": self.analysis.sifs_int["median"].K_II_interac,
+                                                      "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].K_II_interac}
         json_dict['SIFs_integral']['T_interac'] = {"unit": "MPa",
-                                                   "mean": self.analysis.sifs_int["mean"]["t_stress_int"],
-                                                   "median": self.analysis.sifs_int["median"]["t_stress_int"],
-                                                   "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"][
-                                                       "t_stress_int"]}
+                                                   "mean": self.analysis.sifs_int["mean"].T_interac,
+                                                   "median": self.analysis.sifs_int["median"].T_interac,
+                                                   "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].T_interac}
         json_dict['SIFs_integral']['K_I_Chen'] = {"unit": "MPa*m^{1/2}",
-                                                  "mean": self.analysis.sifs_int["mean"]["k_i_chen"],
-                                                  "median": self.analysis.sifs_int["median"]["k_i_chen"],
-                                                  "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"][
-                                                      "k_i_chen"]}
+                                                  "mean": self.analysis.sifs_int["mean"].K_I_Chen,
+                                                  "median": self.analysis.sifs_int["median"].K_I_Chen,
+                                                  "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].K_I_Chen}
         json_dict['SIFs_integral']['K_II_Chen'] = {"unit": "MPa*m^{1/2}",
-                                                   "mean": self.analysis.sifs_int["mean"]["k_ii_chen"],
-                                                   "median": self.analysis.sifs_int["median"]["k_ii_chen"],
-                                                   "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"][
-                                                       "k_ii_chen"]}
+                                                   "mean": self.analysis.sifs_int["mean"].K_II_Chen,
+                                                   "median": self.analysis.sifs_int["median"].K_II_Chen,
+                                                   "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].K_II_Chen}
         json_dict['SIFs_integral']['T_Chen'] = {"unit": "MPa",
-                                                "mean": self.analysis.sifs_int["mean"]["t_stress_chen"],
-                                                "median": self.analysis.sifs_int["median"]["t_stress_chen"],
-                                                "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"][
-                                                    "t_stress_chen"]}
+                                                "mean": self.analysis.sifs_int["mean"].T_Chen,
+                                                "median": self.analysis.sifs_int["median"].T_Chen,
+                                                "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].T_Chen}
         json_dict['SIFs_integral']['T_SDM'] = {"unit": "MPa",
-                                               "mean": self.analysis.sifs_int["mean"]["t_stress_sdm"],
-                                               "median": self.analysis.sifs_int["median"]["t_stress_sdm"],
-                                               "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"][
-                                                   "t_stress_sdm"]}
+                                               "mean": self.analysis.sifs_int["mean"].T_SDM,
+                                               "median": self.analysis.sifs_int["median"].T_SDM,
+                                               "mean_wo_outliers": self.analysis.sifs_int["rej_out_mean"].T_SDM}
 
         if self.analysis.integral_properties.buckner_williams_terms is not None:
             json_dict['Bueckner_Chen_integral'] = {}
             terms = self.analysis.williams_int[0, :, 0]
             for i, term in enumerate(terms):
                 json_dict['Bueckner_Chen_integral'][f'a_{term:.0f}'] = {"unit": unit_of_williams_coefficients(term),
-                                                                        "mean": self.analysis.sifs_int["mean"][
-                                                                            "williams_int_a_n"][i],
-                                                                        "median": self.analysis.sifs_int["median"][
-                                                                            "williams_int_a_n"][i],
-                                                                        "mean_wo_outliers":
-                                                                            self.analysis.sifs_int["rej_out_mean"][
-                                                                                "williams_int_a_n"][i]}
+                                                                        "mean": self.analysis.sifs_int["williams_int_a_n"]["mean"][i],
+                                                                        "median": self.analysis.sifs_int["williams_int_a_n"]["median"][i],
+                                                                        "mean_wo_outliers": self.analysis.sifs_int["williams_int_a_n"]["rej_out_mean"][i]}
             for i, term in enumerate(terms):
                 json_dict['Bueckner_Chen_integral'][f'b_{term:.0f}'] = {"unit": unit_of_williams_coefficients(term),
-                                                                        "mean": self.analysis.sifs_int["mean"][
-                                                                            "williams_int_b_n"][i],
-                                                                        "median": self.analysis.sifs_int["median"][
-                                                                            "williams_int_b_n"][i],
-                                                                        "mean_wo_outliers":
-                                                                            self.analysis.sifs_int["rej_out_mean"][
-                                                                                "williams_int_b_n"][i]}
+                                                                        "mean": self.analysis.sifs_int["williams_int_b_n"]["mean"][i],
+                                                                        "median": self.analysis.sifs_int["williams_int_b_n"]["median"][i],
+                                                                        "mean_wo_outliers": self.analysis.sifs_int["williams_int_b_n"]["rej_out_mean"][i]}
 
         json_dict['Path_SIFs'] = {}
         json_dict['Path_SIFs']['J'] = {"unit": "N/mm",

--- a/crackpy/structure_elements/results.py
+++ b/crackpy/structure_elements/results.py
@@ -1,11 +1,11 @@
-"""Pydantic models holding fracture analysis results.
+"""Dataclasses describing fracture analysis results.
 
-Each model mirrors the tag definitions in :mod:`crackpy.structure_elements.tags`.
-Fields expose alias, unit, label and LTM (Length-Time-Mass exponents) metadata
-for later processing or plotting.
+Each dataclass mirrors the tag definitions in :mod:`crackpy.structure_elements.tags`
+and stores unit and label information in the field metadata for convenient
+consumption by plotting and output utilities.
 """
 
-from pydantic import BaseModel, Field, create_model
+from dataclasses import dataclass, field, make_dataclass
 
 from .tags import (
     TagCJPModel,
@@ -16,297 +16,93 @@ from .tags import (
 )
 
 
+# CJP model results ------------------------------------------------------------
+
 tag_cjp = TagCJPModel()
-class CJPResults(BaseModel):
-    error: float = Field(
-        ...,
-        alias=tag_cjp.error["tag"],
-        unit=tag_cjp.error["unit"],
-        ltm=tag_cjp.error["ltm"],
-        label=tag_cjp.error["label"],
-    )
-    K_F: float = Field(
-        ...,
-        alias=tag_cjp.K_F["tag"],
-        unit=tag_cjp.K_F["unit"],
-        ltm=tag_cjp.K_F["ltm"],
-        label=tag_cjp.K_F["label"],
-    )
-    K_R: float = Field(
-        ...,
-        alias=tag_cjp.K_R["tag"],
-        unit=tag_cjp.K_R["unit"],
-        ltm=tag_cjp.K_R["ltm"],
-        label=tag_cjp.K_R["label"],
-    )
-    K_S: float = Field(
-        ...,
-        alias=tag_cjp.K_S["tag"],
-        unit=tag_cjp.K_S["unit"],
-        ltm=tag_cjp.K_S["ltm"],
-        label=tag_cjp.K_S["label"],
-    )
-    K_II: float = Field(
-        ...,
-        alias=tag_cjp.K_II["tag"],
-        unit=tag_cjp.K_II["unit"],
-        ltm=tag_cjp.K_II["ltm"],
-        label=tag_cjp.K_II["label"],
-    )
-    K_eff_Yang: float = Field(
-        ...,
-        alias=tag_cjp.K_eff_Yang["tag"],
-        unit=tag_cjp.K_eff_Yang["unit"],
-        ltm=tag_cjp.K_eff_Yang["ltm"],
-        label=tag_cjp.K_eff_Yang["label"],
-    )
-    K_eff_Nowell: float = Field(
-        ...,
-        alias=tag_cjp.K_eff_Nowell["tag"],
-        unit=tag_cjp.K_eff_Nowell["unit"],
-        ltm=tag_cjp.K_eff_Nowell["ltm"],
-        label=tag_cjp.K_eff_Nowell["label"],
-    )
-    T: float = Field(
-        ...,
-        alias=tag_cjp.T["tag"],
-        unit=tag_cjp.T["unit"],
-        ltm=tag_cjp.T["ltm"],
-        label=tag_cjp.T["label"],
-    )
 
-    class Config:
-        allow_population_by_field_name = True
+@dataclass
+class CJPResults:
+    error: float = field(metadata={"unit": tag_cjp.error["unit"], "label": tag_cjp.error["label"]})
+    K_F: float = field(metadata={"unit": tag_cjp.K_F["unit"], "label": tag_cjp.K_F["label"]})
+    K_R: float = field(metadata={"unit": tag_cjp.K_R["unit"], "label": tag_cjp.K_R["label"]})
+    K_S: float = field(metadata={"unit": tag_cjp.K_S["unit"], "label": tag_cjp.K_S["label"]})
+    K_II: float = field(metadata={"unit": tag_cjp.K_II["unit"], "label": tag_cjp.K_II["label"]})
+    K_eff_Yang: float = field(metadata={"unit": tag_cjp.K_eff_Yang["unit"], "label": tag_cjp.K_eff_Yang["label"]})
+    K_eff_Nowell: float = field(metadata={"unit": tag_cjp.K_eff_Nowell["unit"], "label": tag_cjp.K_eff_Nowell["label"]})
+    T: float = field(metadata={"unit": tag_cjp.T["unit"], "label": tag_cjp.T["label"]})
 
+
+# Williams fitting results -----------------------------------------------------
 
 tag_williams = TagWillimasFitting()
 
 def _create_williams_model(orders=tag_williams.orders):
-    fields = {
-        'error': (float, Field(..., alias=tag_williams.error['tag'], unit=tag_williams.error['unit'], ltm=tag_williams.error['ltm'], label=tag_williams.error['label'])),
-        'K_I': (float, Field(..., alias=tag_williams.K_I['tag'], unit=tag_williams.K_I['unit'], ltm=tag_williams.K_I['ltm'], label=tag_williams.K_I['label'])),
-        'K_II': (float, Field(..., alias=tag_williams.K_II['tag'], unit=tag_williams.K_II['unit'], ltm=tag_williams.K_II['ltm'], label=tag_williams.K_II['label'])),
-        'K_V': (float, Field(..., alias=tag_williams.K_V['tag'], unit=tag_williams.K_V['unit'], ltm=tag_williams.K_V['ltm'], label=tag_williams.K_V['label'])),
-        'T': (float, Field(..., alias=tag_williams.T['tag'], unit=tag_williams.T['unit'], ltm=tag_williams.T['ltm'], label=tag_williams.T['label'])),
-    }
+    fields = [
+        ("error", float, field(metadata={"unit": tag_williams.error["unit"], "label": tag_williams.error["label"]})),
+        ("K_I", float, field(metadata={"unit": tag_williams.K_I["unit"], "label": tag_williams.K_I["label"]})),
+        ("K_II", float, field(metadata={"unit": tag_williams.K_II["unit"], "label": tag_williams.K_II["label"]})),
+        ("K_V", float, field(metadata={"unit": tag_williams.K_V["unit"], "label": tag_williams.K_V["label"]})),
+        ("T", float, field(metadata={"unit": tag_williams.T["unit"], "label": tag_williams.T["label"]})),
+    ]
     for n in orders:
-        a = tag_williams.coeff('a', n)
-        b = tag_williams.coeff('b', n)
-        fields[f'a_{n}'] = (float, Field(..., alias=a['tag'], unit=a['unit'], ltm=a['ltm'], label=a['label']))
-        fields[f'b_{n}'] = (float, Field(..., alias=b['tag'], unit=b['unit'], ltm=b['ltm'], label=b['label']))
-    model = create_model('WilliamsODMResults', __config__=type('Config', (), {'allow_population_by_field_name': True}), **fields)
-    return model
+        a = tag_williams.coeff("a", n)
+        b = tag_williams.coeff("b", n)
+        fields.append((f"a_{n}", float, field(metadata={"unit": a["unit"], "label": a["label"]})))
+        fields.append((f"b_{n}", float, field(metadata={"unit": b["unit"], "label": b["label"]})))
+    return make_dataclass("WilliamsODMResults", fields)
+
 
 WilliamsODMResults = _create_williams_model()
 
 
 # Integral result models -------------------------------------------------------
+
+# Mean values ------------------------------------------------------------------
+
 tag_int_mean = TagSIFIntegralEvalMean()
-class SIFsIntegralMeanResults(BaseModel):
-    J: float = Field(
-        ...,
-        alias=tag_int_mean.J["tag"],
-        unit=tag_int_mean.J["unit"],
-        ltm=tag_int_mean.J["ltm"],
-        label=tag_int_mean.J["label"],
-    )
-    K_J: float = Field(
-        ...,
-        alias=tag_int_mean.K_J["tag"],
-        unit=tag_int_mean.K_J["unit"],
-        ltm=tag_int_mean.K_J["ltm"],
-        label=tag_int_mean.K_J["label"],
-    )
-    K_I_interac: float = Field(
-        ...,
-        alias=tag_int_mean.K_I_interac["tag"],
-        unit=tag_int_mean.K_I_interac["unit"],
-        ltm=tag_int_mean.K_I_interac["ltm"],
-        label=tag_int_mean.K_I_interac["label"],
-    )
-    K_II_interac: float = Field(
-        ...,
-        alias=tag_int_mean.K_II_interac["tag"],
-        unit=tag_int_mean.K_II_interac["unit"],
-        ltm=tag_int_mean.K_II_interac["ltm"],
-        label=tag_int_mean.K_II_interac["label"],
-    )
-    T_interac: float = Field(
-        ...,
-        alias=tag_int_mean.T_interac["tag"],
-        unit=tag_int_mean.T_interac["unit"],
-        ltm=tag_int_mean.T_interac["ltm"],
-        label=tag_int_mean.T_interac["label"],
-    )
-    K_I_Chen: float = Field(
-        ...,
-        alias=tag_int_mean.K_I_Chen["tag"],
-        unit=tag_int_mean.K_I_Chen["unit"],
-        ltm=tag_int_mean.K_I_Chen["ltm"],
-        label=tag_int_mean.K_I_Chen["label"],
-    )
-    K_II_Chen: float = Field(
-        ...,
-        alias=tag_int_mean.K_II_Chen["tag"],
-        unit=tag_int_mean.K_II_Chen["unit"],
-        ltm=tag_int_mean.K_II_Chen["ltm"],
-        label=tag_int_mean.K_II_Chen["label"],
-    )
-    T_Chen: float = Field(
-        ...,
-        alias=tag_int_mean.T_Chen["tag"],
-        unit=tag_int_mean.T_Chen["unit"],
-        ltm=tag_int_mean.T_Chen["ltm"],
-        label=tag_int_mean.T_Chen["label"],
-    )
-    T_SDM: float = Field(
-        ...,
-        alias=tag_int_mean.T_SDM["tag"],
-        unit=tag_int_mean.T_SDM["unit"],
-        ltm=tag_int_mean.T_SDM["ltm"],
-        label=tag_int_mean.T_SDM["label"],
-    )
 
-    class Config:
-        allow_population_by_field_name = True
+@dataclass
+class SIFsIntegralMeanResults:
+    J: float = field(metadata={"unit": tag_int_mean.J["unit"], "label": tag_int_mean.J["label"]})
+    K_J: float = field(metadata={"unit": tag_int_mean.K_J["unit"], "label": tag_int_mean.K_J["label"]})
+    K_I_interac: float = field(metadata={"unit": tag_int_mean.K_I_interac["unit"], "label": tag_int_mean.K_I_interac["label"]})
+    K_II_interac: float = field(metadata={"unit": tag_int_mean.K_II_interac["unit"], "label": tag_int_mean.K_II_interac["label"]})
+    T_interac: float = field(metadata={"unit": tag_int_mean.T_interac["unit"], "label": tag_int_mean.T_interac["label"]})
+    K_I_Chen: float = field(metadata={"unit": tag_int_mean.K_I_Chen["unit"], "label": tag_int_mean.K_I_Chen["label"]})
+    K_II_Chen: float = field(metadata={"unit": tag_int_mean.K_II_Chen["unit"], "label": tag_int_mean.K_II_Chen["label"]})
+    T_Chen: float = field(metadata={"unit": tag_int_mean.T_Chen["unit"], "label": tag_int_mean.T_Chen["label"]})
+    T_SDM: float = field(metadata={"unit": tag_int_mean.T_SDM["unit"], "label": tag_int_mean.T_SDM["label"]})
 
+
+# Median values ----------------------------------------------------------------
 
 tag_int_median = TagSIFIntegralEvalMedian()
-class SIFsIntegralMedianResults(BaseModel):
-    J: float = Field(
-        ...,
-        alias=tag_int_median.J["tag"],
-        unit=tag_int_median.J["unit"],
-        ltm=tag_int_median.J["ltm"],
-        label=tag_int_median.J["label"],
-    )
-    K_J: float = Field(
-        ...,
-        alias=tag_int_median.K_J["tag"],
-        unit=tag_int_median.K_J["unit"],
-        ltm=tag_int_median.K_J["ltm"],
-        label=tag_int_median.K_J["label"],
-    )
-    K_I_interac: float = Field(
-        ...,
-        alias=tag_int_median.K_I_interac["tag"],
-        unit=tag_int_median.K_I_interac["unit"],
-        ltm=tag_int_median.K_I_interac["ltm"],
-        label=tag_int_median.K_I_interac["label"],
-    )
-    K_II_interac: float = Field(
-        ...,
-        alias=tag_int_median.K_II_interac["tag"],
-        unit=tag_int_median.K_II_interac["unit"],
-        ltm=tag_int_median.K_II_interac["ltm"],
-        label=tag_int_median.K_II_interac["label"],
-    )
-    T_interac: float = Field(
-        ...,
-        alias=tag_int_median.T_interac["tag"],
-        unit=tag_int_median.T_interac["unit"],
-        ltm=tag_int_median.T_interac["ltm"],
-        label=tag_int_median.T_interac["label"],
-    )
-    K_I_Chen: float = Field(
-        ...,
-        alias=tag_int_median.K_I_Chen["tag"],
-        unit=tag_int_median.K_I_Chen["unit"],
-        ltm=tag_int_median.K_I_Chen["ltm"],
-        label=tag_int_median.K_I_Chen["label"],
-    )
-    K_II_Chen: float = Field(
-        ...,
-        alias=tag_int_median.K_II_Chen["tag"],
-        unit=tag_int_median.K_II_Chen["unit"],
-        ltm=tag_int_median.K_II_Chen["ltm"],
-        label=tag_int_median.K_II_Chen["label"],
-    )
-    T_Chen: float = Field(
-        ...,
-        alias=tag_int_median.T_Chen["tag"],
-        unit=tag_int_median.T_Chen["unit"],
-        ltm=tag_int_median.T_Chen["ltm"],
-        label=tag_int_median.T_Chen["label"],
-    )
-    T_SDM: float = Field(
-        ...,
-        alias=tag_int_median.T_SDM["tag"],
-        unit=tag_int_median.T_SDM["unit"],
-        ltm=tag_int_median.T_SDM["ltm"],
-        label=tag_int_median.T_SDM["label"],
-    )
 
-    class Config:
-        allow_population_by_field_name = True
+@dataclass
+class SIFsIntegralMedianResults:
+    J: float = field(metadata={"unit": tag_int_median.J["unit"], "label": tag_int_median.J["label"]})
+    K_J: float = field(metadata={"unit": tag_int_median.K_J["unit"], "label": tag_int_median.K_J["label"]})
+    K_I_interac: float = field(metadata={"unit": tag_int_median.K_I_interac["unit"], "label": tag_int_median.K_I_interac["label"]})
+    K_II_interac: float = field(metadata={"unit": tag_int_median.K_II_interac["unit"], "label": tag_int_median.K_II_interac["label"]})
+    T_interac: float = field(metadata={"unit": tag_int_median.T_interac["unit"], "label": tag_int_median.T_interac["label"]})
+    K_I_Chen: float = field(metadata={"unit": tag_int_median.K_I_Chen["unit"], "label": tag_int_median.K_I_Chen["label"]})
+    K_II_Chen: float = field(metadata={"unit": tag_int_median.K_II_Chen["unit"], "label": tag_int_median.K_II_Chen["label"]})
+    T_Chen: float = field(metadata={"unit": tag_int_median.T_Chen["unit"], "label": tag_int_median.T_Chen["label"]})
+    T_SDM: float = field(metadata={"unit": tag_int_median.T_SDM["unit"], "label": tag_int_median.T_SDM["label"]})
 
+
+# Mean values without outliers -------------------------------------------------
 
 tag_int_rej = TagSIFIntegralEvalMeanWOoutliers()
-class SIFsIntegralMeanwoOutlierResults(BaseModel):
-    J: float = Field(
-        ...,
-        alias=tag_int_rej.J["tag"],
-        unit=tag_int_rej.J["unit"],
-        ltm=tag_int_rej.J["ltm"],
-        label=tag_int_rej.J["label"],
-    )
-    K_J: float = Field(
-        ...,
-        alias=tag_int_rej.K_J["tag"],
-        unit=tag_int_rej.K_J["unit"],
-        ltm=tag_int_rej.K_J["ltm"],
-        label=tag_int_rej.K_J["label"],
-    )
-    K_I_interac: float = Field(
-        ...,
-        alias=tag_int_rej.K_I_interac["tag"],
-        unit=tag_int_rej.K_I_interac["unit"],
-        ltm=tag_int_rej.K_I_interac["ltm"],
-        label=tag_int_rej.K_I_interac["label"],
-    )
-    K_II_interac: float = Field(
-        ...,
-        alias=tag_int_rej.K_II_interac["tag"],
-        unit=tag_int_rej.K_II_interac["unit"],
-        ltm=tag_int_rej.K_II_interac["ltm"],
-        label=tag_int_rej.K_II_interac["label"],
-    )
-    T_interac: float = Field(
-        ...,
-        alias=tag_int_rej.T_interac["tag"],
-        unit=tag_int_rej.T_interac["unit"],
-        ltm=tag_int_rej.T_interac["ltm"],
-        label=tag_int_rej.T_interac["label"],
-    )
-    K_I_Chen: float = Field(
-        ...,
-        alias=tag_int_rej.K_I_Chen["tag"],
-        unit=tag_int_rej.K_I_Chen["unit"],
-        ltm=tag_int_rej.K_I_Chen["ltm"],
-        label=tag_int_rej.K_I_Chen["label"],
-    )
-    K_II_Chen: float = Field(
-        ...,
-        alias=tag_int_rej.K_II_Chen["tag"],
-        unit=tag_int_rej.K_II_Chen["unit"],
-        ltm=tag_int_rej.K_II_Chen["ltm"],
-        label=tag_int_rej.K_II_Chen["label"],
-    )
-    T_Chen: float = Field(
-        ...,
-        alias=tag_int_rej.T_Chen["tag"],
-        unit=tag_int_rej.T_Chen["unit"],
-        ltm=tag_int_rej.T_Chen["ltm"],
-        label=tag_int_rej.T_Chen["label"],
-    )
-    T_SDM: float = Field(
-        ...,
-        alias=tag_int_rej.T_SDM["tag"],
-        unit=tag_int_rej.T_SDM["unit"],
-        ltm=tag_int_rej.T_SDM["ltm"],
-        label=tag_int_rej.T_SDM["label"],
-    )
 
-    class Config:
-        allow_population_by_field_name = True
-
+@dataclass
+class SIFsIntegralMeanwoOutlierResults:
+    J: float = field(metadata={"unit": tag_int_rej.J["unit"], "label": tag_int_rej.J["label"]})
+    K_J: float = field(metadata={"unit": tag_int_rej.K_J["unit"], "label": tag_int_rej.K_J["label"]})
+    K_I_interac: float = field(metadata={"unit": tag_int_rej.K_I_interac["unit"], "label": tag_int_rej.K_I_interac["label"]})
+    K_II_interac: float = field(metadata={"unit": tag_int_rej.K_II_interac["unit"], "label": tag_int_rej.K_II_interac["label"]})
+    T_interac: float = field(metadata={"unit": tag_int_rej.T_interac["unit"], "label": tag_int_rej.T_interac["label"]})
+    K_I_Chen: float = field(metadata={"unit": tag_int_rej.K_I_Chen["unit"], "label": tag_int_rej.K_I_Chen["label"]})
+    K_II_Chen: float = field(metadata={"unit": tag_int_rej.K_II_Chen["unit"], "label": tag_int_rej.K_II_Chen["label"]})
+    T_Chen: float = field(metadata={"unit": tag_int_rej.T_Chen["unit"], "label": tag_int_rej.T_Chen["label"]})
+    T_SDM: float = field(metadata={"unit": tag_int_rej.T_SDM["unit"], "label": tag_int_rej.T_SDM["label"]})

--- a/test_scripts/test_fracture_analysis.py
+++ b/test_scripts/test_fracture_analysis.py
@@ -69,24 +69,24 @@ class TestFractureAnalysis(unittest.TestCase):
         analysis.run()
 
         # test filtered outlier results
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['j'], 1.8699, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['sif_j'], 11.6028, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].J, 1.8699, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].K_J, 11.6028, delta=1e-4)
 
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['sif_k_i'], 11.0096, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['sif_k_ii'], -0.9243, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].K_I_interac, 11.0096, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].K_II_interac, -0.9243, delta=1e-4)
 
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['t_stress_int'], -42.1799, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['t_stress_sdm'], -62.8528, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].T_interac, -42.1799, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].T_SDM, -62.8528, delta=1e-4)
 
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_a_n'][0], 107.9594, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_a_n'][1], 129.1896, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_a_n'][2], -20.1644, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_a_n'][3], 5.7811, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_a_n']['rej_out_mean'][0], 107.9594, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_a_n']['rej_out_mean'][1], 129.1896, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_a_n']['rej_out_mean'][2], -20.1644, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_a_n']['rej_out_mean'][3], 5.7811, delta=1e-4)
 
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_b_n'][0], 19.5458, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_b_n'][1], 8.2752, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_b_n'][2], -1.2748, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_b_n'][3], 0.5349, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_b_n']['rej_out_mean'][0], 19.5458, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_b_n']['rej_out_mean'][1], 8.2752, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_b_n']['rej_out_mean'][2], -1.2748, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_b_n']['rej_out_mean'][3], 0.5349, delta=1e-4)
 
         temp_dir = tempfile.mkdtemp()
         try:
@@ -135,24 +135,24 @@ class TestFractureAnalysis(unittest.TestCase):
         analysis.run()
 
         # test filtered outlier results
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['j'], 1.8813, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['sif_j'], 11.6381, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].J, 1.8813, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].K_J, 11.6381, delta=1e-4)
 
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['sif_k_i'], 11.0188, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['sif_k_ii'], -0.9064, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].K_I_interac, 11.0188, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].K_II_interac, -0.9064, delta=1e-4)
 
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['t_stress_int'], -42.5591, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['t_stress_sdm'], -62.8528, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].T_interac, -42.5591, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean'].T_SDM, -62.8528, delta=1e-4)
 
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_a_n'][0], 109.4747, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_a_n'][1], 129.0193, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_a_n'][2], -20.1845, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_a_n'][3], 5.7942, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_a_n']['rej_out_mean'][0], 109.4747, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_a_n']['rej_out_mean'][1], 129.0193, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_a_n']['rej_out_mean'][2], -20.1845, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_a_n']['rej_out_mean'][3], 5.7942, delta=1e-4)
 
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_b_n'][0], 19.8578, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_b_n'][1], 8.3570, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_b_n'][2], -1.2922, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_int['rej_out_mean']['williams_int_b_n'][3], 0.5393, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_b_n']['rej_out_mean'][0], 19.8578, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_b_n']['rej_out_mean'][1], 8.3570, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_b_n']['rej_out_mean'][2], -1.2922, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_int['williams_int_b_n']['rej_out_mean'][3], 0.5393, delta=1e-4)
 
         temp_dir = tempfile.mkdtemp()
         try:
@@ -188,16 +188,16 @@ class TestFractureAnalysis(unittest.TestCase):
         analysis.run()
 
         # test CJP results
-        self.assertAlmostEqual(analysis.res_cjp['K_F'], 10.7934, delta=1e-4)
-        self.assertAlmostEqual(analysis.res_cjp['K_R'], 2.2790, delta=1e-4)
-        self.assertAlmostEqual(analysis.res_cjp['K_S'], -1.1568, delta=1e-4)
-        self.assertAlmostEqual(analysis.res_cjp['K_II'], -0.0275, delta=1e-4)
-        self.assertAlmostEqual(analysis.res_cjp['T'], -32.1685, delta=1e-4)
+        self.assertAlmostEqual(analysis.res_cjp.K_F, 10.7934, delta=1e-4)
+        self.assertAlmostEqual(analysis.res_cjp.K_R, 2.2790, delta=1e-4)
+        self.assertAlmostEqual(analysis.res_cjp.K_S, -1.1568, delta=1e-4)
+        self.assertAlmostEqual(analysis.res_cjp.K_II, -0.0275, delta=1e-4)
+        self.assertAlmostEqual(analysis.res_cjp.T, -32.1685, delta=1e-4)
 
         # test Williams results
-        self.assertAlmostEqual(analysis.sifs_fit['K_I'], 11.3232, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_fit['K_II'], -1.1102, delta=1e-4)
-        self.assertAlmostEqual(analysis.sifs_fit['T'], -44.3513, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_fit.K_I, 11.3232, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_fit.K_II, -1.1102, delta=1e-4)
+        self.assertAlmostEqual(analysis.sifs_fit.T, -44.3513, delta=1e-4)
 
         self.assertAlmostEqual(analysis.williams_fit_a_n[-3], -195.3576, delta=1e-4)
         self.assertAlmostEqual(analysis.williams_fit_a_n[-2], 6.6082, delta=1e-4)


### PR DESCRIPTION
## Summary
- rewrite results models using dataclasses with metadata
- dynamically build Williams results class via `make_dataclass`

## Testing
- `pip install -r requirements-codex-base.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyvista')*


------
https://chatgpt.com/codex/tasks/task_e_686824eade6c832c93f46ddbd30dff0e